### PR TITLE
Use getServerSideProps instead of getStaticProps

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -5,7 +5,7 @@ import Head from 'next/head'
 import Container from 'react-bootstrap/Container'
 import KleptonixNavbar from '../components/navbar'
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
 
   let prisma
 
@@ -21,8 +21,7 @@ export async function getStaticProps() {
   const posts = await prisma.posts.findMany()
 
   return {
-    props: { posts },
-    revalidate: 1
+    props: { posts }
   }
 }
 


### PR DESCRIPTION
`getStaticProps()` doesn't work at build\-time if Prisma can't connect to the database. Therefore, `getServerSideProps()` must be used instead.