### PR TITLE
Remove extra backtick, add a postcard to index

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To build locally, you'll need `node` installed along with `yarn`. You will also 
 
 ```sh
 yarn install
-````
+```
 
 and wait for the dependencies to be installed. After this, you need to have a database set up the way Prisma expects it to be. To achieve this, run
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -192,7 +192,21 @@ export default function Home({ user }) {
                     klepton="rust"
                     text={
                       "##### What is Rust?\n" +
-                      "Rust is a programming language. We don't need to talk about it."
+                      "Rust is a programming language. We don't need to talk about it, unless there's some reason why you need to crunch numbers."
+                    }
+                    views={0}
+                    replies={0}
+                  />
+                </div>
+                <div className="col-md-6 py-2">
+                  <Postcard
+                    title="Java is Not a Programming Language"
+                    author="Luis Bauza"
+                    username="luis"
+                    klepton="java"
+                    text={
+                      "##### What is Java?\n" +
+                      "Believe it or not, most developers don't know that Java refers to a cup of coffee and not a programming language."
                     }
                     views={0}
                     replies={0}


### PR DESCRIPTION
Add a postcard to the index page to round out the basic layout, remove an unnecessary backtick from the README.md as a small formatting fix.